### PR TITLE
Fix serialization loop

### DIFF
--- a/Pages/Templates/Designer.cshtml
+++ b/Pages/Templates/Designer.cshtml
@@ -468,8 +468,21 @@
     <script>
         // Initialize designer with template data
         (function() {
-            const templateData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Template, JsonSerializerOptions.Web));
-            const uploadedImages = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.UploadedImages, JsonSerializerOptions.Web));
+            const templateData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(new {
+                pageWidth = Model.Template.PageWidth,
+                pageHeight = Model.Template.PageHeight,
+                templateJson = Model.Template.TemplateJson
+            }, JsonSerializerOptions.Web));
+            const uploadedImages = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
+                Model.UploadedImages.Select(img => new {
+                    id = img.Id,
+                    name = img.Name,
+                    dataUri = img.DataUri,
+                    widthPx = img.WidthPx,
+                    heightPx = img.HeightPx
+                }),
+                JsonSerializerOptions.Web
+            ));
             const editMode = @Model.IsEditMode.ToString().ToLower();
             const systemTemplate = @Model.IsSystemTemplate.ToString().ToLower();
 


### PR DESCRIPTION
  Problem

  Designer page threw JsonException: A possible object cycle was detected when attempting to edit templates. The
  error path showed: $.Connection.User.Connections.User.Connections...

  Root Cause

  Designer.cshtml:471 serialized the full Model.Template and Model.UploadedImages objects including navigation
  properties, creating a circular reference chain:
  - Template → Connection → User → Connections → back to Connection...

  Solution

  Replaced full object serialization with anonymous objects containing only the properties JavaScript actually uses:

  templateData: pageWidth, pageHeight, templateJson (3 properties instead of entire entity)uploadedImages: id, name,
   dataUri, widthPx, heightPx (5 properties instead of entire entity)

  This eliminates navigation properties from serialization while providing all required data to the client.

  Testing

  Designer page now loads successfully without serialization errors.